### PR TITLE
Update test to catch Alice balance underflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -258,9 +258,9 @@ require (
 
 //replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101500.0-rc.3
 
-replace github.com/ethereum/go-ethereum => github.com/yuwen01/op-geth v1.0.2-operatorfee
+//replace github.com/ethereum/go-ethereum => github.com/yuwen01/op-geth v1.0.2-operatorfee
 
-//replace github.com/ethereum/go-ethereum => ../op-geth
+replace github.com/ethereum/go-ethereum => ../op-geth
 
 // replace github.com/ethereum-optimism/superchain-registry/superchain => ../superchain-registry/superchain
 

--- a/go.sum
+++ b/go.sum
@@ -847,8 +847,6 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw=
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/yuwen01/op-geth v1.0.2-operatorfee h1:+wFpvgbHwv+74a3UXFhipHvfZQfe+hcLxtIk5cLbp84=
-github.com/yuwen01/op-geth v1.0.2-operatorfee/go.mod h1:OMpyVMMy5zpAAHlR5s/aGbXRk+7cIKczUEIJj54APbY=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=


### PR DESCRIPTION
Can run with

```
go test -v ./actions/proofs/... -run Test_Operator_Fee_Constistency

...

=== NAME  Test_Operator_Fee_Constistency/HonestClaim-OperatorFeeConstistency-Isthmus
    operator_fee_test.go:93: 
        	Error Trace:	/Users/teddyknox/Workspace/optimism/op-e2e/actions/proofs/operator_fee_test.go:93
        	            				/Users/teddyknox/Workspace/optimism/op-e2e/actions/proofs/helpers/matrix.go:41
        	Error:      	Should be false
        	Test:       	Test_Operator_Fee_Constistency/HonestClaim-OperatorFeeConstistency-Isthmus
        	Messages:   	Alice's initialbalance should not overflow
```

The true value of Alice's balance is high as the result of an underflow.